### PR TITLE
Removed Space a event trigger

### DIFF
--- a/resources/js/greeter.js
+++ b/resources/js/greeter.js
@@ -284,7 +284,6 @@ function key_press_handler(event) {
   let action = null;
   switch (event.code) {
     case "Enter":
-    case "Space":
       action =
         selected_user != null
           ? provide_secret


### PR DESCRIPTION
Removed "Space" as a trigger for "provide_secret" cause you cant have spaces in you password with "Space" as a trigger. Maybe there is a another solution to this but I couldn't find any.